### PR TITLE
Release for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,9 @@
 ## [v0.1.0](https://github.com/aereal/coll/commits/v0.1.0) - 2025-04-17
 - feat: init by @aereal in https://github.com/aereal/coll/pull/1
 - feat: add OrderedSet by @aereal in https://github.com/aereal/coll/pull/2
+- chore(deps): update actions/setup-go action to v5 by @renovate in https://github.com/aereal/coll/pull/4
+- chore: set version by @aereal in https://github.com/aereal/coll/pull/6
+
+## [v0.1.0](https://github.com/aereal/coll/commits/v0.1.0) - 2025-04-17
+- feat: init by @aereal in https://github.com/aereal/coll/pull/1
+- feat: add OrderedSet by @aereal in https://github.com/aereal/coll/pull/2


### PR DESCRIPTION
This pull request is for the next release as v0.1.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: init by @aereal in https://github.com/aereal/coll/pull/1
* feat: add OrderedSet by @aereal in https://github.com/aereal/coll/pull/2
* chore(deps): update actions/setup-go action to v5 by @renovate in https://github.com/aereal/coll/pull/4
* chore: set version by @aereal in https://github.com/aereal/coll/pull/6

## New Contributors
* @aereal made their first contribution in https://github.com/aereal/coll/pull/1
* @renovate made their first contribution in https://github.com/aereal/coll/pull/4

**Full Changelog**: https://github.com/aereal/coll/commits/v0.1.0